### PR TITLE
crosstools-ng: back port complib/ppl-0.11.2 with gcc 4.9 patch

### DIFF
--- a/patches/crosstool-NG/complibs-ppl-Fix-build-of-ppl-0.11.2-with-gcc-4.9.patch
+++ b/patches/crosstool-NG/complibs-ppl-Fix-build-of-ppl-0.11.2-with-gcc-4.9.patch
@@ -1,0 +1,126 @@
+From 6ab70a6fb2a760dfd55c88ae61283b761311d754 Mon Sep 17 00:00:00 2001
+From: Bernhard Walle <bernhard@bwalle.de>
+Date: Sun, 11 May 2014 13:00:36 +0200
+Subject: [PATCH 1/1] complibs/ppl: Fix build of ppl 0.11.2 with gcc 4.9
+
+  From: Roberto Bagnara <bagnara@cs.unipr.it>
+  Date: Tue, 29 Apr 2014 19:51:43 +0000 (+0200)
+  Subject: Added missing inclusions.  Use std::ptrdiff_t.
+  X-Git-Url: http://www.cs.unipr.it/git/gitweb.cgi?p=ppl%2Fppl.git;a=commitdiff;h=61d4e14dfd9f1121e9b4521dead5728b2424dd7c
+
+  Added missing inclusions.  Use std::ptrdiff_t.
+  (Thanks to Paulo Cesar Pereira de Andrade.)
+
+Signed-off-by: Bernhard Walle <bernhard@bwalle.de>
+Message-Id: <5632a171e7c1dc4c0fb5.1399806148@euler.fritz.box>
+Patchwork-Id: 347777
+Signed-off-by: Curt Brune <curt@cumulusnetworks.com>
+---
+ patches/ppl/0.11.2/500-ptrdiff_t.patch |   95 ++++++++++++++++++++++++++++++++
+ 1 file changed, 95 insertions(+)
+ create mode 100644 patches/ppl/0.11.2/500-ptrdiff_t.patch
+
+diff --git a/patches/ppl/0.11.2/500-ptrdiff_t.patch b/patches/ppl/0.11.2/500-ptrdiff_t.patch
+new file mode 100644
+index 0000000..af26cf9
+--- /dev/null
++++ b/patches/ppl/0.11.2/500-ptrdiff_t.patch
+@@ -0,0 +1,95 @@
++From: Bernhard Walle <bernhard@bwalle.de>
++Subject: Fix compilation with gcc 4.9 (ptrdiff_t errors)
++
++This is a backport of following patch in ppl git
++
++  commit 61d4e14dfd9f1121e9b4521dead5728b2424dd7c
++  Author: Roberto Bagnara <bagnara@cs.unipr.it>
++  Date:   Tue Apr 29 21:51:43 2014 +0200
++
++      Added missing inclusions.  Use std::ptrdiff_t.
++      (Thanks to Paulo Cesar Pereira de Andrade.)
++
++---
++ src/Congruence_System.defs.hh     |    3 ++-
++ src/Constraint_System.defs.hh     |    3 ++-
++ src/Generator_System.defs.hh      |    3 ++-
++ src/Grid_Generator_System.defs.hh |    3 ++-
++ 4 files changed, 8 insertions(+), 4 deletions(-)
++
++--- a/src/Grid_Generator_System.defs.hh
+++++ b/src/Grid_Generator_System.defs.hh
++@@ -30,6 +30,7 @@ site: http://www.cs.unipr.it/ppl/ . */
++ #include "Variables_Set.types.hh"
++ #include "Grid.types.hh"
++ #include <iosfwd>
+++#include <cstddef>
++ 
++ namespace Parma_Polyhedra_Library {
++ 
++@@ -267,7 +268,7 @@ public:
++   class const_iterator
++     : public std::iterator<std::forward_iterator_tag,
++ 			   Grid_Generator,
++-			   ptrdiff_t,
+++			   std::ptrdiff_t,
++ 			   const Grid_Generator*,
++ 			   const Grid_Generator&>,
++       private Generator_System::const_iterator {
++--- a/src/Congruence_System.defs.hh
+++++ b/src/Congruence_System.defs.hh
++@@ -33,6 +33,7 @@ site: http://www.cs.unipr.it/ppl/ . */
++ #include "Grid.types.hh"
++ #include "Grid_Certificate.types.hh"
++ #include <iosfwd>
+++#include <cstddef>
++ 
++ namespace Parma_Polyhedra_Library {
++ 
++@@ -235,7 +236,7 @@ public:
++   class const_iterator
++     : public std::iterator<std::forward_iterator_tag,
++ 			   Congruence,
++-			   ptrdiff_t,
+++			   std::ptrdiff_t,
++ 			   const Congruence*,
++ 			   const Congruence&> {
++   public:
++--- a/src/Constraint_System.defs.hh
+++++ b/src/Constraint_System.defs.hh
++@@ -33,6 +33,7 @@ site: http://www.cs.unipr.it/ppl/ . */
++ #include "Congruence_System.types.hh"
++ #include <iterator>
++ #include <iosfwd>
+++#include <cstddef>
++ 
++ namespace Parma_Polyhedra_Library {
++ 
++@@ -204,7 +205,7 @@ public:
++   class const_iterator
++     : public std::iterator<std::forward_iterator_tag,
++ 			   Constraint,
++-			   ptrdiff_t,
+++			   std::ptrdiff_t,
++ 			   const Constraint*,
++ 			   const Constraint&> {
++   public:
++--- a/src/Generator_System.defs.hh
+++++ b/src/Generator_System.defs.hh
++@@ -33,6 +33,7 @@ site: http://www.cs.unipr.it/ppl/ . */
++ #include "Polyhedron.types.hh"
++ #include "Poly_Con_Relation.defs.hh"
++ #include <iosfwd>
+++#include <cstddef>
++ 
++ namespace Parma_Polyhedra_Library {
++ 
++@@ -250,7 +251,7 @@ public:
++   class const_iterator
++     : public std::iterator<std::forward_iterator_tag,
++ 			   Generator,
++-			   ptrdiff_t,
+++			   std::ptrdiff_t,
++ 			   const Generator*,
++ 			   const Generator&> {
++   public:
+-- 
+1.7.10.4
+

--- a/patches/crosstool-NG/series
+++ b/patches/crosstool-NG/series
@@ -4,3 +4,4 @@ gcc-4-7-3-powerpc-uclibc-math-library.patch
 libc-sysdeps-add-__kernel_long.patch
 linux-custom-support-patches.patch
 linux-fsl-sdk-v1.5-install-headers-argument-too-long.patch
+complibs-ppl-Fix-build-of-ppl-0.11.2-with-gcc-4.9.patch


### PR DESCRIPTION
This patch back ports an upstream crosstools-ng patch that fixes a
problem building ppl 0.11.2 with gcc 4.9.

See the patch for details about the issue and corrective action.

This patch fixes #104

Testing Done:

Compiled and tested toolchain using Debian stable(wheezy)  (gcc-4.7.2)
Compiled and tested toolchain using Debian testing(jessie) (gcc-4.9.1)